### PR TITLE
Fix for Members Typeahead not working.

### DIFF
--- a/post-type/module-base.php
+++ b/post-type/module-base.php
@@ -673,7 +673,11 @@ class DT_Training_Base extends DT_Module_Base {
                     <h3><?php echo esc_html_x( "Add members from existing contacts", 'Add members modal', 'disciple-tools-training' )?></h3>
                     <p><?php echo esc_html_x( "In the 'Member List' field, type the name of an existing contact to add them to this training.", 'Add members modal', 'disciple-tools-training' )?></p>
 
-                    <?php render_field_for_display( "members", $training_fields, $training, false ); ?>
+                    <?php 
+                    $training_member_list = $training_fields;
+                    $training_member_list["members"]['custom_display'] = false;
+                    
+                    render_field_for_display( "members", $training_member_list, $training, false ); ?>
 
                     <div class="grid-x pin-to-bottom">
                         <div class="cell">

--- a/post-type/module-base.php
+++ b/post-type/module-base.php
@@ -673,10 +673,9 @@ class DT_Training_Base extends DT_Module_Base {
                     <h3><?php echo esc_html_x( "Add members from existing contacts", 'Add members modal', 'disciple-tools-training' )?></h3>
                     <p><?php echo esc_html_x( "In the 'Member List' field, type the name of an existing contact to add them to this training.", 'Add members modal', 'disciple-tools-training' )?></p>
 
-                    <?php 
+                    <?php
                     $training_member_list = $training_fields;
                     $training_member_list["members"]['custom_display'] = false;
-                    
                     render_field_for_display( "members", $training_member_list, $training, false ); ?>
 
                     <div class="grid-x pin-to-bottom">


### PR DESCRIPTION
The main problem is that the members field has the custom_display value set to false, so when it is passed to the `render_field_for_display` function it returns empty. If you simply make the custom_display field false it then causes a problem because the field gets rendered twice once in the modal and once in the tile. This causes a duplicate ID and causes problems in the JS. 

What I have done here is kept the custom_display set to true so it doesn't get displayed in the tile, but before we pass it to `render_field_for_display` in `module-base.php:680` I change the custom_display value to false so that it will get output from the render function. 

There is probably a better solution here, but this does solve it.